### PR TITLE
Resolves #7. Update message text length validation to allow up to 250…

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -7,9 +7,18 @@ namespace RazorPagesTestSample.Data
     {
         public int Id { get; set; }
 
+        /// <summary>
+        /// Gets or sets the text of the message.
+        /// </summary>
+        /// <remarks>
+        /// The text should be a string with a maximum length of 250 characters.
+        /// </remarks>
+        /// <value>
+        /// The text of the message.
+        /// </value>
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request includes a small change to the `Message` class in the `src/Application/src/RazorPagesTestSample/Data/Message.cs` file. The change involves updating the maximum length of the `Text` property and adding XML documentation comments.

Changes to `Message` class:

* Increased the maximum length of the `Text` property from 200 to 250 characters and updated the error message accordingly.
* Added XML documentation comments for the `Text` property, including a summary, remarks, and value description