### PR TITLE
Fix unit tests. Resolves #18.

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore ./src/Application/src/RazorPagesTestSample/RazorPagesTestSample.csproj
     - name: Test
-      run: dotnet test --no-build --verbosity normal ./src/Application/tests/RazorPagesTestSample.Tests/RazorPagesTestSample.Tests.csproj
+      run: dotnet test --verbosity normal ./src/Application/tests/RazorPagesTestSample.Tests/RazorPagesTestSample.Tests.csproj
       
   dockerBuildPush:
     runs-on: ubuntu-latest

--- a/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
+++ b/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
@@ -41,10 +41,11 @@ namespace RazorPagesTestSample.Tests.UnitTests
 
                 // Act
                 await db.AddMessageAsync(expectedMessage);
+                var fakeMessage = new Message() { Id = recId, Text = "Invalid!" };
 
                 // Assert
                 var actualMessage = await db.FindAsync<Message>(recId);
-                Assert.Equal(expectedMessage, actualMessage);
+                Assert.Equal(fakeMessage, actualMessage);
             }
         }
 

--- a/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
+++ b/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
@@ -41,11 +41,10 @@ namespace RazorPagesTestSample.Tests.UnitTests
 
                 // Act
                 await db.AddMessageAsync(expectedMessage);
-                var fakeMessage = new Message() { Id = recId, Text = "Invalid!" };
 
                 // Assert
                 var actualMessage = await db.FindAsync<Message>(recId);
-                Assert.Equal(fakeMessage, actualMessage);
+                Assert.Equal(expectedMessage, actualMessage);
             }
         }
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy-app.yml` file. The change simplifies the `Test` job by removing the `--no-build` flag from the `dotnet test` command.

* [`.github/workflows/deploy-app.yml`](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581L35-R35): Removed the `--no-build` flag from the `dotnet test` command in the `Test` job.